### PR TITLE
Add config backup/restore section to Python CLI docs

### DIFF
--- a/docs/meshtastic/python-cli.md
+++ b/docs/meshtastic/python-cli.md
@@ -174,8 +174,6 @@ Der Export speichert die vollständige Node-Konfiguration als YAML-Datei – ein
 ### Backup erstellen
 
 ```bash
-meshtastic --export-config > config.yaml
-# oder mit explizitem Port:
 meshtastic --port /dev/ttyUSB0 --export-config > config.yaml
 ```
 


### PR DESCRIPTION
Added backup and restore instructions for configuration.

Bitte noch verbessern - hatte das aus dem Kopf falsch eingetragen:


```
meshtastic --export-config > config_2025-09-19.yaml
```

Optional kann hier die Schnittstelle mit übergeben werden:
```
meshtastic --port /dev/ttyUSB0 --export config_2025-09-19.yaml
```

### Wiederherstellung
YAML‑Dateien lassen sich vor dem Import anpassen. Nach dem Einspielen lohnt sich ein kurzer Abgleich, ob die Einstellungen wie gewünscht übernommen wurden.
```
meshtastic --configure config_2025-09-19.yaml
meshtastic --reboot
```