### PR TITLE
MeshCore: Add path debugging to companion setup

### DIFF
--- a/docs/meshcore/companion-setup.md
+++ b/docs/meshcore/companion-setup.md
@@ -149,7 +149,6 @@ Der Pfad wird nur gespeichert, wenn die App **zum Zeitpunkt des Empfangs** mit d
 | Heard Repeats | gesendete Nachricht | ein Repeater, dessen Weiterleitung bei mir ankam | fehlt = direkt erreichbar; x hops = nur über Umweg |
 | View Message Paths | empfangene Nachricht | ein Repeater in direkter Hörweite | Hops der Nachricht bis zu diesem Repeater |
 
-Siehst du einen Repeater in „View Message Paths", aber nicht in „Heard Repeats", dann hörst du ihn – er hört dich aber nicht. Das ist ein typisches Zeichen für einen asymmetrischen Link.
 
 ## Adverts verstehen
 

--- a/docs/meshcore/companion-setup.md
+++ b/docs/meshcore/companion-setup.md
@@ -120,10 +120,10 @@ Welche Repeater haben meine gesendete Nachricht gehört und weitergeleitet?
 2. Wähle „Heard Repeats"
 3. Jede Zeile ist ein Repeater, dessen Weiterleitung bei dir ankam
 
-Die **„x hops"**-Angabe zeigt, wie viele Zwischenstationen die Wiederholung des Repeaters auf dem Weg zurück zu dir hatte:
+Die optionale **„x hops"**-Angabe zeigt, wie viele Zwischenstationen die Weiterleitung des Repeaters auf dem Weg zurück zu dir hatte:
 
-- **1 hop** – du hörst diesen Repeater direkt, er ist in direkter Funkreichweite
-- **2+ hops** – die Weiterleitung dieses Repeaters erreichte dich nur über andere Repeater; du kannst ihn hören, erreichst ihn aber nicht direkt
+- **keine Angabe** – du hörst diesen Repeater direkt, seine Weiterleitung erreichte dich ohne Umweg
+- **x hops** – die Weiterleitung erreichte dich über x weitere Repeater; du kannst ihn hören, er ist aber nicht direkt erreichbar
 
 ### Nachrichtenpfad empfangener Nachrichten
 
@@ -146,7 +146,7 @@ Der Pfad wird nur gespeichert, wenn die App **zum Zeitpunkt des Empfangs** mit d
 
 | Funktion | Langer Druck auf | Jede Zeile ist… | „x hops" bedeutet… |
 |----------|-----------------|-----------------|---------------------|
-| Heard Repeats | gesendete Nachricht | ein Repeater, dessen Weiterleitung bei mir ankam | Hops der Weiterleitung zurück zu mir |
+| Heard Repeats | gesendete Nachricht | ein Repeater, dessen Weiterleitung bei mir ankam | fehlt = direkt erreichbar; x hops = nur über Umweg |
 | View Message Paths | empfangene Nachricht | ein Repeater in direkter Hörweite | Hops der Nachricht bis zu diesem Repeater |
 
 Siehst du einen Repeater in „View Message Paths", aber nicht in „Heard Repeats", dann hörst du ihn – er hört dich aber nicht. Das ist ein typisches Zeichen für einen asymmetrischen Link.

--- a/docs/meshcore/companion-setup.md
+++ b/docs/meshcore/companion-setup.md
@@ -114,11 +114,32 @@ Unter **Einstellungen → Message Settings** lassen sich zusätzliche Infos unte
 
 ### Heard Repeats anzeigen
 
-Für Details, welche Repeater in Reichweite sind:
+Welche Repeater haben meine Nachricht weitergeleitet?
 
-1. Drücke lange auf eine gesendete Nachricht
-2. Wähle "Heard Repeats"
-3. Siehst du eine Liste der Repeater, die deine Nachricht weitertragen haben
+1. Drücke lange auf eine **gesendete** Nachricht
+2. Wähle „Heard Repeats"
+3. Die Liste zeigt alle Repeater, die deine Nachricht empfangen und weitergeleitet haben
+
+### Nachrichtenpfad empfangener Nachrichten
+
+Über welchen Weg ist eine Nachricht zu mir gelangt?
+
+1. Drücke lange auf eine **empfangene** Nachricht
+2. Wähle „Message Path"
+3. Die Liste zeigt die Repeater, über die die Nachricht zu dir weitergeleitet wurde
+
+:::info App muss verbunden sein
+Der Pfad wird nur gespeichert, wenn die App **zum Zeitpunkt des Empfangs** mit deiner Node verbunden war. Im Hintergrund empfangene Nachrichten zeigen keinen Pfad.
+:::
+
+**Unterschied auf einen Blick:**
+
+| Funktion | Langer Druck auf | Zeigt |
+|----------|-----------------|-------|
+| Heard Repeats | gesendete Nachricht | Repeater, die mich gehört haben |
+| Message Path | empfangene Nachricht | Repeater, über die eine Nachricht ankam |
+
+Beide Funktionen zusammen helfen dir, asymmetrische Links zu erkennen: Wenn du Repeater X im Message Path siehst, aber nicht in Heard Repeats, hört der Repeater dich nicht – nur du ihn.
 
 ## Adverts verstehen
 

--- a/docs/meshcore/companion-setup.md
+++ b/docs/meshcore/companion-setup.md
@@ -114,19 +114,29 @@ Unter **Einstellungen → Message Settings** lassen sich zusätzliche Infos unte
 
 ### Heard Repeats anzeigen
 
-Welche Repeater haben meine Nachricht weitergeleitet?
+Welche Repeater haben meine gesendete Nachricht gehört und weitergeleitet?
 
 1. Drücke lange auf eine **gesendete** Nachricht
 2. Wähle „Heard Repeats"
-3. Die Liste zeigt alle Repeater, die deine Nachricht empfangen und weitergeleitet haben
+3. Jede Zeile ist ein Repeater, dessen Weiterleitung bei dir ankam
+
+Die **„x hops"**-Angabe zeigt, wie viele Zwischenstationen die Wiederholung des Repeaters auf dem Weg zurück zu dir hatte:
+
+- **1 hop** – du hörst diesen Repeater direkt, er ist in direkter Funkreichweite
+- **2+ hops** – die Weiterleitung dieses Repeaters erreichte dich nur über andere Repeater; du kannst ihn hören, erreichst ihn aber nicht direkt
 
 ### Nachrichtenpfad empfangener Nachrichten
 
-Über welchen Weg ist eine Nachricht zu mir gelangt?
+Über welche Repeater ist eine Flood-Nachricht eines anderen Teilnehmers zu mir gelangt?
 
-1. Drücke lange auf eine **empfangene** Nachricht
-2. Wähle „Message Path"
-3. Die Liste zeigt die Repeater, über die die Nachricht zu dir weitergeleitet wurde
+1. Drücke lange auf eine **empfangene** Nachricht in einem Kanal
+2. Wähle „View Message Paths"
+3. Jede Zeile ist ein Repeater in direkter Hörweite, von dem du die Nachricht empfangen hast
+
+Die **„x hops"**-Angabe zeigt, wie viele Sprünge die Nachricht innerhalb des Netzes zurücklegte, bevor sie den Repeater erreichte, den du direkt hörst:
+
+- **1 hop** – der Sender hat den Repeater in deiner Hörweite direkt erreicht
+- **2+ hops** – die Nachricht passierte vorher noch weitere Repeater, bevor sie bei dem ankam, den du empfängst
 
 :::info App muss verbunden sein
 Der Pfad wird nur gespeichert, wenn die App **zum Zeitpunkt des Empfangs** mit deiner Node verbunden war. Im Hintergrund empfangene Nachrichten zeigen keinen Pfad.
@@ -134,12 +144,12 @@ Der Pfad wird nur gespeichert, wenn die App **zum Zeitpunkt des Empfangs** mit d
 
 **Unterschied auf einen Blick:**
 
-| Funktion | Langer Druck auf | Zeigt |
-|----------|-----------------|-------|
-| Heard Repeats | gesendete Nachricht | Repeater, die mich gehört haben |
-| Message Path | empfangene Nachricht | Repeater, über die eine Nachricht ankam |
+| Funktion | Langer Druck auf | Jede Zeile ist… | „x hops" bedeutet… |
+|----------|-----------------|-----------------|---------------------|
+| Heard Repeats | gesendete Nachricht | ein Repeater, dessen Weiterleitung bei mir ankam | Hops der Weiterleitung zurück zu mir |
+| View Message Paths | empfangene Nachricht | ein Repeater in direkter Hörweite | Hops der Nachricht bis zu diesem Repeater |
 
-Beide Funktionen zusammen helfen dir, asymmetrische Links zu erkennen: Wenn du Repeater X im Message Path siehst, aber nicht in Heard Repeats, hört der Repeater dich nicht – nur du ihn.
+Siehst du einen Repeater in „View Message Paths", aber nicht in „Heard Repeats", dann hörst du ihn – er hört dich aber nicht. Das ist ein typisches Zeichen für einen asymmetrischen Link.
 
 ## Adverts verstehen
 


### PR DESCRIPTION
## Summary

- Erweitert den Abschnitt „Heard Repeats anzeigen" um klarere Formulierung (gesendete vs. empfangene Nachricht explizit markiert)
- Fügt neuen Abschnitt „Nachrichtenpfad empfangener Nachrichten" hinzu: langer Druck → „Message Path"
- Info-Box: App muss zum Empfangszeitpunkt verbunden sein, sonst kein Pfad gespeichert
- Vergleichstabelle Heard Repeats vs. Message Path
- Erklärt praktisch, wie asymmetrische Links erkennbar sind

## Hintergrund

Aus der WhatsApp-Auswertung (MC-6): Das Pfad-Debugging ist eines der nützlichsten Diagnose-Werkzeuge in MeshCore, aber kaum jemand findet es ohne Hinweis — „Wer kommt schon auf die Idee, lange auf die Nachricht zu tippen?" (MeshCoreRheinland, Z. 820). Untergebracht in der bestehenden „Funktion überprüfen"-Sektion der companion-setup.md, keine neue Unterseite nötig.