### PR TITLE
Add WhatsApp community join landing page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@open-iframe-resizer/core": "^2.3.1",
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
+        "qrcode.react": "^4.2.0",
         "react": "^19.0.0",
         "react-cookie-consent": "^9.0.0",
         "react-dom": "^19.0.0"
@@ -9865,6 +9866,20 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -16370,6 +16385,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@open-iframe-resizer/core": "^2.3.1",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
+    "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-cookie-consent": "^9.0.0",
     "react-dom": "^19.0.0"

--- a/src/pages/join/index.tsx
+++ b/src/pages/join/index.tsx
@@ -1,0 +1,101 @@
+import type {ReactNode} from 'react';
+import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
+import Heading from '@theme/Heading';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+
+const MESHTASTIC_URL = 'https://chat.whatsapp.com/CRYnRrAzhYeDlQEJQZQpKi';
+const MESHCORE_URL = 'https://chat.whatsapp.com/JyNcTcgwlJf6Mhhf7vgYWD';
+
+function QrCode({url}: {url: string}): ReactNode {
+  return (
+    <BrowserOnly fallback={<div style={{width: 200, height: 200}} />}>
+      {() => {
+        const {QRCodeSVG} = require('qrcode.react');
+        return <QRCodeSVG value={url} size={200} level="M" includeMargin={false} />;
+      }}
+    </BrowserOnly>
+  );
+}
+
+function Protocol({title, url, docsPath}: {title: string; url: string; docsPath: string}): ReactNode {
+  return (
+    <div className="col col--6 text--center" style={{padding: '1.5rem 1rem'}}>
+      <Heading as="h2">{title}</Heading>
+      <div style={{display: 'flex', justifyContent: 'center', margin: '1.25rem 0'}}>
+        <QrCode url={url} />
+      </div>
+      <a className="button button--primary button--lg" href={url} target="_blank" rel="noopener noreferrer">
+        WhatsApp-Community beitreten
+      </a>
+      <p style={{marginTop: '1rem'}}>
+        <Link to={docsPath}>Zur Dokumentation</Link>
+      </p>
+    </div>
+  );
+}
+
+export default function Join(): ReactNode {
+  return (
+    <Layout
+      title="Mesh Rheinland - Community beitreten"
+      description="Du hast unsere Einladung empfangen. Tritt unserer Meshtastic- oder MeshCore-Community im Rheinland bei."
+>
+      <header className="hero hero--primary">
+        <div className="container">
+          <Heading as="h1" className="hero__title">
+            Du hast gerade unsere Einladung empfangen!
+          </Heading>
+          <p className="hero__subtitle">
+            Willkommen bei Mesh Rheinland. Kommunikation ohne Internet und ohne Mobilfunk.
+            Wähle dein Protokoll und tritt der passenden WhatsApp-Community bei.
+          </p>
+        </div>
+      </header>
+
+      <main>
+        <div className="container" style={{padding: '2.5rem 1rem 1rem'}}>
+          <div className="row">
+            <div className="col col--4">
+              <h3>Wer wir sind</h3>
+              <p>
+                Mesh Rheinland ist eine offene Community von über fünfhundert Hobbyisten, Funkamateuren und
+                Technikbegeisterten entlang des Rheins. Jeder ist eingeladen mitzumachen,
+                unabhängig vom Standort oder Erfahrungsstand.
+              </p>
+            </div>
+            <div className="col col--4">
+              <h3>Was uns ausmacht</h3>
+              <p>
+                Bei uns geht es um mehr als Technik oder Notfunk! Wir fachsimpeln, tauschen Ideen aus,
+                helfen uns gegenseitig und treffen uns wann immer möglich. Die Gemeinschaft steht
+                im Mittelpunkt.
+              </p>
+            </div>
+            <div className="col col--4">
+              <h3>Warum beitreten?</h3>
+              <p>
+                Ob du gerade erst anfängst oder schon tief im Thema steckst: In der Gruppe
+                findest du Gleichgesinnte, bekommst schnell Antworten und gestaltest das Netz
+                aktiv mit. Jeder Beitrag hilft, es besser zu machen.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="container" style={{padding: '1rem 0 2.5rem'}}>
+          <hr />
+          <div className="row">
+            <Protocol title="Meshtastic" url={MESHTASTIC_URL} docsPath="/meshtastic/intro" />
+            <Protocol title="MeshCore" url={MESHCORE_URL} docsPath="/meshcore/intro" />
+          </div>
+          <p className="text--center" style={{marginTop: '2rem'}}>
+            Du hast diese Einladung ungebeten empfangen oder bevorzugst eine andere Plattform als WhatsApp?
+            Wir freuen uns über konstruktives Feedback:{' '}
+            <a href="mailto:rennleitung@meshrheinland.de">rennleitung@meshrheinland.de</a>.
+          </p>
+        </div>
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary

- Single landing page at `/join` with two-column layout (Meshtastic / MeshCore)
- QR codes generated from WhatsApp community URLs via `qrcode.react`
- Community description: who we are, what sets us apart, why to join
- Feedback contact line for unsolicited invitations or platform concerns
- Not linked in the main nav — reached exclusively via LoRa message

## Background

Community leads post WhatsApp invite links from elevated locations via LoRa mesh messages. Problem: recipients had no context before joining. This landing page solves that: a short URL fits within the 220-character LoRa message limit and explains the community before anyone commits to joining.

**Suggested LoRa message template (97 chars):**
```
Hi! Du empfaengst mich via LoRa. Wir sind eine Mesh-Community im Rheinland. Infos & WhatsApp: www.meshrheinland.de/join
```

## Test plan

- [ ] `/join` renders with both QR codes visible
- [ ] Scan each QR code with a phone — lands in the correct WhatsApp community
- [ ] WhatsApp buttons open the correct links
- [ ] Documentation links resolve correctly
- [ ] `npm run build` passes without errors