### PR TITLE
Fix admonition syntax for Docusaurus v4 compatibility

### DIFF
--- a/docs/hardware/antennen.md
+++ b/docs/hardware/antennen.md
@@ -124,7 +124,7 @@ Empfehlenswert wenn Störsender in der Nähe sind - der Bandpassfilter schützt 
 
 Selbstgebaute Antennen können sehr gute Ergebnisse liefern, sofern mit einem VNA abgestimmt wird. Beliebte Varianten:
 
-:::tip Abstimmung im Gehäuse vornehmen
+:::tip[Abstimmung im Gehäuse vornehmen]
 Wer die Antenne in einem Kunststoffrohr oder -gehäuse unterbringt, sollte die Abstimmung mit dem VNA **im eingebauten Zustand** durchführen. Das umgebende Kunststoffmaterial erhöht die Dielektrizitätszahl und verschiebt die Resonanzfrequenz je nach Material und Wandstärke nach unten. Eine freistehend auf 868 MHz abgestimmte Antenne kann im Rohr dann auf 840 MHz oder tiefer resonieren.
 :::
 

--- a/docs/hardware/geraete.md
+++ b/docs/hardware/geraete.md
@@ -26,7 +26,7 @@ Empfohlene LoRa-Geräte für Meshtastic und MeshCore im Rheinland.
   <img src="/img/hardware/devices/elecrow-thinknode-m6-back.jpg" alt="Elecrow ThinkNode M6 Rückseite" style={{width: '50%'}} />
 </div>
 
-:::note Hinweis
+:::note[Hinweis]
 Die Hinweise aus dem [Heise‑Artikel](https://www.heise.de/news/Elecrow-ThinkNode-M6-Solarbetriebener-Meshtastic-Knoten-fuer-Ausseneinsatz-11187337.html) beachten. [Herstellerseite](https://www.elecrow.com/thinknode-m6-outdoor-solar-power-for-meshtastic-powered-by-nrf52840-supports-gps.html) - [Wiki](https://www.elecrow.com/pub/wiki/ThinkNode_M6_Outdoor_Solar_Power_for_Meshtastic_Powered_By_nRF52840_Supports_GPS.html) - [Manual](https://www.elecrow.com/download/product/LMM14106D/ThinkNode_M6_Outdoor_Solar_Power_for_Meshtastic_User_Manual.pdf)
 :::
 
@@ -210,7 +210,7 @@ Klassiker mit WiFi – ideal für MQTT-Bridge, Gateway oder feste Installation m
 
 Kompakter GPS-Tracker im Kreditkartenformat mit integriertem 700 mAh Akku und IP65-Schutz. Trotz kleiner, interner Antenne erreicht er überraschend gute Reichweiten und genießt große Beliebtheit. Besonderheit: Integrierte Sensoren für Temperatur, Licht und Bewegung sowie Status-LED, Buzzer und Bedientaster. Wird mit magnetischem Ladekabel geliefert.
 
-:::note Hinweis
+:::note[Hinweis]
 Achte beim Kauf darauf, die „for Meshtastic"-Version zu wählen. [Herstellerseite](https://www.seeedstudio.com/SenseCAP-Card-Tracker-T1000-E-for-Meshtastic-p-5913.html) · [Wiki](https://wiki.seeedstudio.com/sensecap_t1000_e/) · [Forum](https://forum.seeedstudio.com/t/sensecap-t1000-e-meshtastic-tracker-user-guide/287783)
 :::
 

--- a/docs/meshcore/channels.md
+++ b/docs/meshcore/channels.md
@@ -22,7 +22,7 @@ Pro Kanal sind Benachrichtigungen individuell konfigurierbar: **Alle Nachrichten
 
 In der Mesh Rheinland Community verwenden wir derzeit folgende Kanäle.
 
-:::info Kanäle sind nicht exklusiv
+:::info[Kanäle sind nicht exklusiv]
 Durch die standardmäßig 64 Hops in MeshCore hat das Mesh eine große Reichweite. Dieselben Kanäle werden häufig auch von anderen Communities genutzt. Diese Übersicht bietet trotzdem einen Einstiegspunkt für neue Teilnehmer und ermöglicht es, Fragen zu unseren Kanälen mit einem Link zu beantworten.
 :::
 

--- a/docs/meshcore/companion-setup.md
+++ b/docs/meshcore/companion-setup.md
@@ -5,7 +5,7 @@ description: Companion-Firmware flashen, Node einrichten und erste Verbindung in
 
 # Companion-Setup
 
-:::warning Wichtige Änderung seit dem 24.04.2026
+:::warning[Wichtige Änderung seit dem 24.04.2026]
 Die Repeater im Mesh Rheinland transportieren keinen ungescopten Verkehr mehr. Aktualisiere deine Firmware auf die neueste Version und stelle sicher, dass du einen **Default Region Scope** gesetzt hast – sonst werden deine Nachrichten nicht weitergetragen.
 :::
 
@@ -45,7 +45,7 @@ Die Einstellungen müssen exakt übereinstimmen, damit die Geräte miteinander k
 - **Spreading Factor**: 8
 - **Coding Rate**: 8
 
-:::info Preset verwenden
+:::info[Preset verwenden]
 Am einfachsten: Wähle das Preset **EU/UK (Narrow)** in den Radio-Einstellungen. Die Parameter werden automatisch korrekt gesetzt.
 :::
 
@@ -70,7 +70,7 @@ Ein Region Scope begrenzt die Weiterleitung deiner Nachrichten auf Repeater, die
 
 </div>
 
-:::tip Regionen pro Kanal
+:::tip[Regionen pro Kanal]
 Der Default Region Scope gilt für alle Kanäle. Für den Einstieg ist das ausreichend – du kannst aber jedem Kanal auch eine eigene Region zuweisen. Wie das geht, erklärt die [Regionen-Seite](regionen).
 :::
 
@@ -138,7 +138,7 @@ Die **„x hops"**-Angabe zeigt, wie viele Sprünge die Nachricht innerhalb des 
 - **1 hop** – der Sender hat den Repeater in deiner Hörweite direkt erreicht
 - **2+ hops** – die Nachricht passierte vorher noch weitere Repeater, bevor sie bei dem ankam, den du empfängst
 
-:::info App muss verbunden sein
+:::info[App muss verbunden sein]
 Der Pfad wird nur gespeichert, wenn die App **zum Zeitpunkt des Empfangs** mit deiner Node verbunden war. Im Hintergrund empfangene Nachrichten zeigen keinen Pfad.
 :::
 
@@ -158,6 +158,6 @@ Der Pfad wird nur gespeichert, wenn die App **zum Zeitpunkt des Empfangs** mit d
 - **Ohne Advert**: Du bist für andere Teilnehmer unsichtbar (Privacy-Feature!)
 - **Mit gelegentlichem Advert**: Du erscheinst auf Netzwerkkarten
 
-:::tip Sichtbarkeit vs. Privatsphäre
+:::tip[Sichtbarkeit vs. Privatsphäre]
 Sendest du als Companion keinen Advert, bist du für andere Teilnehmer unsichtbar. Sende hin und wieder einen Advert, wenn du auf der Netzwerkkarte erscheinen möchtest.
 :::

--- a/docs/meshcore/firmware-flashen.md
+++ b/docs/meshcore/firmware-flashen.md
@@ -18,12 +18,12 @@ Der einfachste Weg zum Erstflashen: Browser, USB-Kabel, fertig.
    - **Repeater** – für unbemannten Infrastrukturbetrieb
    - **Room Server** – für den BBS-Modus
 
-:::danger Companion BLE oder USB?
+:::danger[Companion BLE oder USB?]
 Für die meisten Nutzer ist **Companion Bluetooth** die richtige Wahl. Die USB-Variante enthält kein Bluetooth – wer sie versehentlich flasht, kann sich nicht per App verbinden und muss neu flashen.
 :::
 4. Verbinde das Gerät per USB und starte den Flash-Vorgang
 
-:::info Chrome oder Edge erforderlich
+:::info[Chrome oder Edge erforderlich]
 Der Web-Flasher benötigt WebSerial – das ist nur in Chromium-basierten Browsern verfügbar.
 :::
 
@@ -37,7 +37,7 @@ RAK-Boards erscheinen nach einem normalen Anstecken nicht als Flash-Laufwerk. Um
 2. **Zweimal schnell** die Reset-Taste drücken
 3. Das Gerät erscheint als USB-Massenspeicher und kann über den Web-Flasher oder per direktem Kopieren der `.uf2`-Datei bespielt werden
 
-:::note macOS
+:::note[macOS]
 Wenn macOS meldet, der Kopiervorgang sei fehlgeschlagen, ist das in der Regel trotzdem erfolgreich. Das Gerät startet nach dem Schreibvorgang neu.
 :::
 
@@ -55,7 +55,7 @@ Wer vorher Meshtastic auf einem **nRF52-Gerät** betrieben hat, sollte vor dem e
 2. Klicke auf **Flash Erase** – der Flasher löscht den Speicher direkt
 3. Danach MeshCore wie oben per Web-Flasher installieren
 
-:::warning Nur bei nRF52 nötig
+:::warning[Nur bei nRF52 nötig]
 Bei ESP32-basierten Geräten (Heltec V3, TTGO etc.) gibt es im Web-Flasher eine Checkbox **„Erase device"**. Sie löscht gespeicherte Konfigurationen und entspricht einem Factory Reset – bei einem Firmware-Wechsel empfehlenswert, aber kein eigener Schritt davor nötig.
 :::
 

--- a/docs/meshcore/intro.md
+++ b/docs/meshcore/intro.md
@@ -26,7 +26,7 @@ MeshCore unterscheidet klar zwischen verschiedenen Rollen:
 - Repeater: Weiterleitung von Nachrichten
 - Room Server: Einfacher BBS-Server für 32 Nachrichten an einer Pinnwand
 
-:::warning Wichtig für neue Nutzer
+:::warning[Wichtig für neue Nutzer]
 Flashe die **Companion**-Firmware! Repeater und Room Server sind für Infrastruktur-Knoten und erlauben keine normale Nutzung als Teilnehmer.
 :::
 

--- a/docs/meshcore/meshcore-ha-integration.md
+++ b/docs/meshcore/meshcore-ha-integration.md
@@ -10,7 +10,7 @@ Diese Seite beschreibt die Integration von MeshCore in Home Assistant auf Basis 
 
 Die Integration ist eine Custom Integration für Home Assistant und erlaubt Monitoring sowie Steuerung von MeshCore-Nodes über **USB**, **BLE** oder **TCP**.
 
-:::warning Status laut Projekt
+:::warning[Status laut Projekt]
 Die Integration ist laut README noch **Work in Progress**. Die BLE-Verbindung wurde dort als noch nicht umfassend getestet beschrieben.
 :::
 

--- a/docs/meshcore/node-id-kollisionen.md
+++ b/docs/meshcore/node-id-kollisionen.md
@@ -42,7 +42,7 @@ set prv.key <dein-generierter-private-key>
 reboot
 ```
 
-:::warning Wichtig
+:::warning[Wichtig]
 Der neue Key wird erst nach einem Neustart aktiv.
 :::
 

--- a/docs/meshcore/ota-update-nrf52.md
+++ b/docs/meshcore/ota-update-nrf52.md
@@ -4,7 +4,7 @@ description: Firmware-Update per Bluetooth (OTA/DFU) für nRF52-basierte MeshCor
 
 # OTA-Update (nRF52)
 
-:::warning Nur für nRF52-basierte Geräte
+:::warning[Nur für nRF52-basierte Geräte]
 Diese Anleitung gilt ausschließlich für Boards mit einem **nRF52**-Chip, z. B. RAK WisBlock oder Xiao nRF52840. ESP32-basierte Geräte (Heltec V3, TTGO etc.) werden anders aktualisiert – dort genügt der Web-Flasher mit aktivierter „Erase device"-Checkbox.
 :::
 
@@ -39,7 +39,7 @@ Der OTA-Modus wird per Remote-Admin aus der App aktiviert:
 
 Die angezeigte MAC-Adresse ist die Bluetooth-Adresse des Repeaters im DFU-Modus – sie wird im nächsten Schritt zur Geräteauswahl benötigt. Erfolgt kein Upload innerhalb des Timeouts, bootet das Gerät automatisch neu und die bestehende Firmware bleibt erhalten.
 
-:::warning Reihenfolge beachten
+:::warning[Reihenfolge beachten]
 Der Befehl lautet `start ota` – nicht `ota start`. Letzteres wird mit `Unknown command` quittiert.
 :::
 
@@ -73,7 +73,7 @@ Für den Upload wird die App **nRF Device Firmware Update** von Nordic Semicondu
 </div>
 </div>
 
-:::tip Warum unterschiedliche Paketanzahlen?
+:::tip[Warum unterschiedliche Paketanzahlen?]
 Die Paketanzahl steuert, wie viele Datenpakete ohne Bestätigung übertragen werden. Die Werte 8 (Xiao) und 10 (RAK) haben sich in der Praxis bewährt – andere Werte können zu fehlgeschlagenen Updates führen.
 :::
 

--- a/docs/meshcore/paketstruktur.md
+++ b/docs/meshcore/paketstruktur.md
@@ -43,7 +43,7 @@ block-beta
 | **Payload** | variabel | Firmware | Das Mesh-Paket (siehe unten) |
 | **CRC-16** | 2 Bytes | LoRa-Chip | Hardware-Checksumme über Payload |
 
-:::tip LoRa-CRC wird automatisch validiert
+:::tip[LoRa-CRC wird automatisch validiert]
 Der LoRa-Chip prüft die CRC-16 automatisch. Nur fehlerfreie Pakete werden an die Firmware übergeben. `setCRC(1)` aktiviert dies in der Firmware.
 :::
 
@@ -175,7 +175,7 @@ Byte  9+:   Payload
 
 ## Längenbestimmung
 
-:::info Keine explizite Payload-Länge
+:::info[Keine explizite Payload-Länge]
 Das Mesh-Protokoll speichert **keine** explizite Payload-Länge. Diese wird implizit berechnet.
 :::
 
@@ -532,6 +532,6 @@ header = (route_type & 0x03)           // Bits 0-1
 | **Header-Größe** | 1 Byte (Route, Type, Version) |
 | **Optionale Felder** | Transport Codes (4 Bytes), Path (0-64 Bytes) |
 
-:::tip Wire-Format ist kompakt
+:::tip[Wire-Format ist kompakt]
 MeshCore nutzt jeden Byte effizient: Keine Padding-Bytes, keine redundanten Längenfelder, keine doppelte Checksumme.
 :::

--- a/docs/meshcore/regionen.md
+++ b/docs/meshcore/regionen.md
@@ -11,7 +11,7 @@ Ein **Scope** ist der geografische Reichweitenwunsch, den ein Nutzer einer Nachr
 - **Repeater-Betreiber** konfigurieren am Repeater, welche Scopes weitergeleitet werden
 - Nur Repeater mit passendem Scope leiten die Nachricht weiter
 
-:::tip Nur für gesendete Nachrichten
+:::tip[Nur für gesendete Nachrichten]
 Der gewählte Scope beeinflusst nur deine gesendeten Nachrichten. Empfangen kannst du alle Nachrichten des Kanals, unabhängig vom Scope.
 :::
 
@@ -44,7 +44,7 @@ In der Mesh Rheinland Community verwenden wir derzeit folgende Regionen:
 - `niederrhein` – Niederrhein
 - `drielande` – Dreiländereck NL/BE/DE (Grenzregion zur Gewährleistung reibungsloser Kommunikation zwischen den Niederlanden, Belgien und Deutschland)
 
-:::tip Kompatibilität
+:::tip[Kompatibilität]
 Da noch keine europaweite Einigung auf eine gemeinsame Region existiert, sollten Repeater **beide** Europa-Regionen erhalten: `europe` und `eu`.
 :::
 
@@ -98,7 +98,7 @@ Um einen Scope von einem Kanal wieder zu entfernen:
 4. Tippe auf die **drei Punkte** oben rechts
 5. Wähle **"Clear Scope"**
 
-:::info Individuelle Anpassung
+:::info[Individuelle Anpassung]
 Die Beispiele zeigen die Rheinland-Regionen. Je nach Standort wirst du andere Regionen verwenden – passe die Liste an deine lokale Community an.
 :::
 
@@ -167,11 +167,11 @@ region save
 - `region default <name>` - gibt den Adverts des Repeaters auch den Scope
 - `region home <name>` - wird nicht verwendet, kann aber bereits gesetzt werden
 
-:::tip Region-Verwaltung
+:::tip[Region-Verwaltung]
 Nach jeder Änderung an Regionen muss `region save` ausgeführt werden, damit die Konfiguration nach einem Neustart erhalten bleibt.
 :::
 
-:::tip Regionen sind in Exports nicht enthalten und werden entsprechend bei einem eventuellen Config Export / Node Flash / Config Import nicht wieder hergestellt. Sichert euch am Besten mit `regions` eure Einstellungen eures Repeaters.
+:::tip[Regionen sind in Exports nicht enthalten und werden entsprechend bei einem eventuellen Config Export / Node Flash / Config Import nicht wieder hergestellt. Sichert euch am Besten mit `regions` eure Einstellungen eures Repeaters.]
 :::
 
 ### Technische Anforderungen

--- a/docs/meshcore/repeater-setup.md
+++ b/docs/meshcore/repeater-setup.md
@@ -2,7 +2,7 @@
 
 Ein Repeater erweitert die Reichweite des MeshCore-Netzwerks, indem er Nachrichten weiterleitet. Diese Anleitung erklärt die wichtigsten Einstellungen für den Betrieb eines Repeaters.
 
-:::warning Nur für Infrastruktur
+:::warning[Nur für Infrastruktur]
 Repeater sind für unbemannten Betrieb gedacht. Für normale Nutzung flashe die **Companion**-Firmware!
 :::
 
@@ -59,7 +59,7 @@ Nach dem Flashen kannst du deinen Repeater über die Web-Oberfläche konfigurier
 
 **Latitude / Longitude**:
 
-:::warning Standort & Privatsphäre
+:::warning[Standort & Privatsphäre]
 Überlege dir genau, welche Position du angibst. Ein Versatz von einigen Metern mit ähnlichen topologischen Eigenschaften schützt deine Privatsphäre, ohne die Netzwerk-Übersicht zu beeinträchtigen.
 :::
 
@@ -67,7 +67,7 @@ Nach dem Flashen kannst du deinen Repeater über die Web-Oberfläche konfigurier
 
 **Guest password**:
 
-:::tip Offener Zugang empfohlen
+:::tip[Offener Zugang empfohlen]
 Lasse das Feld **leer**, damit sich jeder ohne Passwort anmelden kann. Dies fördert die offene Nutzung des Mesh-Netzwerks.
 :::
 
@@ -85,11 +85,11 @@ Die Radio-Parameter sollten automatisch korrekt gesetzt sein:
 - **TX Power**: 22 dBm
 - **Duty Cycle**: 10%
 
-:::info Duty Cycle
+:::info[Duty Cycle]
 `set dutycycle 10` begrenzt die Sendezeit auf 10 % (ETSI EN300.220-2 für Deutschland).
 :::
 
-:::info Einstellungen speichern
+:::info[Einstellungen speichern]
 Klicke nach allen Änderungen auf "Save settings" am unteren Rand.
 :::
 
@@ -97,7 +97,7 @@ Klicke nach allen Änderungen auf "Save settings" am unteren Rand.
 
 Nach dem Speichern der Einstellungen klicke auf **"Send Advert"**, damit dein Repeater im Netzwerk sichtbar wird.
 
-:::info Erweiterte Konfiguration
+:::info[Erweiterte Konfiguration]
 Für erweiterte Einstellungen, die über die Web-Oberfläche hinausgehen, steht die [Repeater CLI Reference](https://github.com/meshcore-dev/MeshCore/wiki/Repeater-&-Room-Server-CLI-Reference) zur Verfügung. Hierüber lassen sich z.B. Advert-Intervalle, Bridging oder Region-Management detailliert konfigurieren.
 :::
 
@@ -109,7 +109,7 @@ Mehr dazu und eine Schritt-für-Schritt-Anleitung zum Generieren eines Custom Ke
 
 ## Regionen konfigurieren
 
-:::tip Wichtiger letzter Schritt
+:::tip[Wichtiger letzter Schritt]
 Nach der Grundkonfiguration solltest du deinen Repeater mit den passenden Regionen ausstatten. Dies ist für das zukünftige Netzwerk essentiell.
 :::
 

--- a/docs/meshcore/room-server.md
+++ b/docs/meshcore/room-server.md
@@ -14,7 +14,7 @@ Im Unterschied zu einem Kanal zwischen zwei Companions benötigst du für einen 
 
 Der Room Server ist eine eigene Firmware-Variante. Im [Web-Flasher](https://flasher.meshcore.io) die Variante **Room Server** für das jeweilige Board auswählen und flashen ([Anleitung](firmware-flashen)).
 
-:::warning Companion Bluetooth enthält keinen Room Server
+:::warning[Companion Bluetooth enthält keinen Room Server]
 Room Server und Companion sind getrennte Firmware-Varianten. Ein Companion-Gerät kann nicht als Room Server fungieren.
 :::
 
@@ -54,7 +54,7 @@ set repeat on
 reboot
 ```
 
-:::warning Nicht empfohlen
+:::warning[Nicht empfohlen]
 Der Betrieb als Repeater wird für Room Server offiziell nicht empfohlen:
 
 - **Airtime**: Ein Room Server erzeugt durch Nachrichtenverteilung bereits hohes TX-Volumen. Die 10 % Duty-Cycle-Grenze reicht kaum für beide Aufgaben.
@@ -91,7 +91,7 @@ Ab diesem Zeitpunkt kennt der Server deinen Client. Neue Nachrichten anderer Tei
 
 Sollte ein Betreten des Room Servers mit bestehendem Pfad nicht mehr möglich sein, setze den Pfad per **„Reset Path"** zurück und starte wieder mit **„Log In • Flood"**. Auf diese Weise wird ein neuer Pfad ausgehandelt und mit etwas Glück gelingt die Anmeldung dieses Mal wieder.
 
-:::info Kein Advert nötig
+:::info[Kein Advert nötig]
 Der Login-Request enthält deinen öffentlichen Schlüssel direkt. Der Room Server führt daraus einen individuellen ECDH-Schlüsselaustausch durch – alle Nachrichten zwischen Server und Client sind Ende-zu-Ende verschlüsselt, ohne dass zuvor ein Advert ausgetauscht werden musste.
 :::
 

--- a/docs/meshcore/routing.md
+++ b/docs/meshcore/routing.md
@@ -34,7 +34,7 @@ graph LR
 
 ## FLOOD-Routing: Schritt für Schritt
 
-:::info Zwei Anwendungsfälle für FLOOD
+:::info[Zwei Anwendungsfälle für FLOOD]
 FLOOD wird für zwei verschiedene Zwecke verwendet:
 1. **Öffentliche Kanalnachrichten**: Broadcast an alle Teilnehmer, **kein** Path Learning
 2. **Private Nachrichten** (erste Nachricht): Path Learning für effiziente Folge-Kommunikation
@@ -93,7 +93,7 @@ Bob empfängt!
 
 Nach dem Empfang einer FLOOD-Nachricht startet ein automatischer Prozess, der **beide Routen gleichzeitig lernt**:
 
-:::warning Payload vs. Path-Header
+:::warning[Payload vs. Path-Header]
 Im PATH-Paket sind zwei verschiedene Routing-Informationen enthalten:
 - **Path-Header** (wächst beim FLOOD): der Reise-Pfad, den *dieses* Paket genommen hat
 - **Payload**: die explizite Route, die der Empfänger für zukünftige DIRECT-Nachrichten nutzen soll
@@ -240,7 +240,7 @@ TX Delay = Zufallszahl(0, 5 × Airtime × tx_delay_factor)
 | **1.0** | 200 ms | 0-1000 ms | Höheres Delay, weniger Kollisionen |
 | **0.0** | 0 ms | 0 ms | TX Delay deaktiviert (nicht empfohlen) |
 
-:::info Anpassung des TX Delay
+:::info[Anpassung des TX Delay]
 Ein höherer `tx_delay_factor` vergrößert den Zufallsbereich und reduziert Kollisionen, erhöht aber die Latenz. Der Default-Wert `0.5` ist für die meisten Netzwerke optimal.
 :::
 

--- a/docs/meshtastic/geraet-flashen.md
+++ b/docs/meshtastic/geraet-flashen.md
@@ -14,7 +14,7 @@ Für den Start benötigst du:
 - ein USB‑Datenkabel
 - einen PC oder Laptop mit aktuellem Chrome‑ oder Edge‑Browser
 
-:::danger Antenne anschließen
+:::danger[Antenne anschließen]
 Vor der Inbetriebnahme müssen alle Antennen angeschlossen sein, ansonsten kann das Gerät dauerhaft beschädigt werden.
 :::
 
@@ -28,7 +28,7 @@ Verbinde das Gerät per USB mit deinem Computer und öffne im Browser den [Mesht
 2. **Firmware:** Wähle die passende Firmware für dein Gerät. Für Einsteiger empfiehlt sich die aktuelle Beta‑Version, da diese stabil läuft und neue Funktionen enthält.
 3. **Flash:** Starte den Flash‑Vorgang, um die Firmware auf dein Gerät zu übertragen.
 
-:::info Hinweis
+:::info[Hinweis]
 Am unteren Rand der Seite findest du hilfreiche Links, unter anderem zu den Spracheinstellungen.
 
 Nach dem Flashen startet das Gerät einmal neu. Warte einige Sekunden, bis es im Web‑Client erscheint. Möchtest du stattdessen mit der App oder dem CLI fortfahren, folge der entsprechenden Anleitung weiter unten.

--- a/docs/meshtastic/geraeterollen.md
+++ b/docs/meshtastic/geraeterollen.md
@@ -45,7 +45,7 @@ Für fest installierte Knoten an strategischen Positionen (Dach, Turm, Mast). Re
 
 Rebroadcastet jede Nachricht zuverlässig wie ROUTER, verwendet aber immer den späten Zeitslot, sodass ROUTER und andere höher priorisierte Nodes zuerst senden können. Geeignet für Standorte, die geografisch isolierte Mesh-Segmente anbinden (Tallagen, Funklöcher hinter Hügeln) – aber nur dort, wo kein normaler ROUTER die Verbindung übernehmen kann.
 
-:::warning Airtime beachten
+:::warning[Airtime beachten]
 ROUTER_LATE erhöht die Gesamtairtime spürbar. ChUtil sollte unter 25 % und AirTxUtil unter 7–8 % bleiben. Für Dachknoten oder mobile Geräte ist CLIENT die bessere Wahl.
 :::
 
@@ -53,7 +53,7 @@ ROUTER_LATE erhöht die Gesamtairtime spürbar. ChUtil sollte unter 25 % und Air
 
 Verhält sich identisch zu ROUTER, aber komplett ohne eigenen Traffic – keine Telemetrie, keine Ankündigungen. Taucht nicht in der Nodes-Liste auf und ist damit nicht remote administrierbar.
 
-:::note Deprecated
+:::note[Deprecated]
 REPEATER ist seit Firmware v2.7.11 deprecated. Für neue Installationen ROUTER verwenden.
 :::
 
@@ -71,7 +71,7 @@ Sendet regelmäßig GPS-Koordinaten mit hoher Priorität. Ideal für mobile Eins
 
 ## Hinweise zur Platzierung
 
-:::warning Router und Repeater sparsam einsetzen
+:::warning[Router und Repeater sparsam einsetzen]
 Zu viele Router oder Repeater in unmittelbarer Nähe verursachen Funkkollisionen und unnötigen Hopsverbrauch. Ungünstig platzierte Knoten degradieren das Netz durch asymmetrische Links.
 :::
 

--- a/docs/meshtastic/grundeinstellungen.md
+++ b/docs/meshtastic/grundeinstellungen.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 Nach dem Flashen der Firmware verbindest du dich per App oder Web‑Client mit deinem Gerät und nimmst die folgenden Einstellungen vor.
 
-:::warning Lokale Vorschriften
+:::warning[Lokale Vorschriften]
 Bitte beachte lokale Funkrichtlinien (z. B. Duty Cycle im 868‑MHz‑Band). Stelle die Region auf EU868 und achte darauf, dass Sendeleistung plus Antennengewinn die erlaubten 27 dBm nicht überschreiten.
 :::
 
@@ -21,7 +21,7 @@ Stelle als Erstes die Region auf **EU868** (Europa/Deutschland):
 
 Im Rheinland nutzen wir das Modem‑Profil **ShortSlow**. Das ist wichtig, denn Geräte mit unterschiedlichen Presets können sich **nicht gegenseitig hören** – ein Gerät auf LongFast und eines auf ShortSlow sprechen aneinander vorbei, als wären sie in getrennten Netzen.
 
-:::warning Nicht der Standard
+:::warning[Nicht der Standard]
 ShortSlow ist nicht die Meshtastic-Standardeinstellung – bitte aktiv umstellen!
 :::
 

--- a/docs/meshtastic/meshtastic-ha-integration.md
+++ b/docs/meshtastic/meshtastic-ha-integration.md
@@ -54,7 +54,7 @@ Als Alternative wird in der README die manuelle Ablage unter `custom_components`
 - Für Automationen wird empfohlen, **Device Triggers/Actions** zu bevorzugen.
 - Bei trigger-basierten Antworten sollte eine kurze Verzögerung eingebaut werden, damit Meshtastic nicht während Senden/Empfangen blockiert ist.
 
-:::warning Sicherheitshinweis zum eingebauten Web Client
+:::warning[Sicherheitshinweis zum eingebauten Web Client]
 Laut README kann die aktivierte Web-Client-Proxy-Funktion zu **unauthenticated access** auf Gateway-Nodes führen, wenn Home Assistant aus nicht vertrauenswürdigen Netzen erreichbar ist.
 Aktiviere diese Funktion nur in einer vertrauenswürdigen Umgebung.
 :::
@@ -63,7 +63,7 @@ Aktiviere diese Funktion nur in einer vertrauenswürdigen Umgebung.
 
 Die offizielle Meshtastic-Seite zur MQTT-Integration beschreibt den manuellen Aufbau von MQTT-Entities in Home Assistant.
 
-:::warning Kompatibilität
+:::warning[Kompatibilität]
 Laut offizieller Meshtastic-MQTT-Doku sind **nRF52-Geräte derzeit nicht für Home Assistant** unterstützt (bekanntes JSON-Problem).
 :::
 

--- a/docs/meshtastic/netzoptimierung.md
+++ b/docs/meshtastic/netzoptimierung.md
@@ -4,7 +4,7 @@ unlisted: true
 
 # Netzoptimierung (Experiment)
 
-:::danger Experiment beendet
+:::danger[Experiment beendet]
 **Update 29.11.2025:** Das Experiment wurde beendet. Leider zu viele Probleme bei der Weitergabe der NodeInfos.
 
 **Hauptproblem:** Die aktuelle Firmware erlaubt uns nicht, Telemetrie- und NodeInfo-Frames unterschiedlich zu behandeln. Entweder wird alles transportiert oder nichts. Beides bringt uns leider nicht weiter.
@@ -74,7 +74,7 @@ Der Link enthält bereits optimierte Einstellungen.
 
 ### Schritt 2: Kanalposition festlegen
 
-:::danger Kritisch
+:::danger[Kritisch]
 Die Kanäle M1 und M2 dürfen **NICHT auf Position 0** liegen!
 :::
 
@@ -95,7 +95,7 @@ Von Routern sollten folgende Kanäle **entfernt** werden:
 
 **Ausnahme:** Lokale Kanäle, die nur in deinem Umkreis genutzt werden, können bleiben.
 
-:::warning Position 0 muss belegt sein
+:::warning[Position 0 muss belegt sein]
 Falls du keinen eigenen Kanal brauchst, erstelle einen Platzhalter-Kanal.
 :::
 
@@ -127,7 +127,7 @@ Falls du keinen eigenen Kanal brauchst, erstelle einen Platzhalter-Kanal.
 
 ### Schritt 2: Kanalposition beachten
 
-:::warning Bitte M1_Messages/M2_Tests nicht als primären Kanal nutzen
+:::warning[Bitte M1_Messages/M2_Tests nicht als primären Kanal nutzen]
 Um das Experiment erfolgreich zu machen, ist es wichtig, dass M1_Messages und M2_Tests **nicht auf Position 0** liegen.
 
 **Hintergrund:** Auf dem primären Kanal (Position 0) wird, wenn aktiviert, die **Telemetrie** gesendet. Für das Experiment möchten wir in M1_Messages und M2_Tests aber nur Nachrichtenverkehr, um das Netz zu entlasten.
@@ -142,7 +142,7 @@ Um das Experiment erfolgreich zu machen, ist es wichtig, dass M1_Messages und M2
 | 2 | M2_Tests | Test-Nachrichten |
 | 3+ | Weitere Kanäle | Nach Bedarf |
 
-:::tip User können ShortSlow behalten
+:::tip[User können ShortSlow behalten]
 Als User kannst du weiterhin auf dem ShortSlow-Kanal unterwegs sein. Füge einfach M1_Messages und M2_Tests hinzu.
 :::
 

--- a/docs/meshtastic/unterstuetzte-sensoren.md
+++ b/docs/meshtastic/unterstuetzte-sensoren.md
@@ -21,7 +21,7 @@ Das Standard‑Sendeintervall für Telemetrie‑Nachrichten beträgt 30 Minuten.
 
 Das Telemetry‑Modul ist per Voreinstellung aktiv für Gerätemetriken. Umgebungs‑, Luftqualitäts‑ und Gesundheitsmetriken müssen in den Moduleinstellungen aktiviert werden – per App, Web‑Interface oder CLI.
 
-:::note Messintervall
+:::note[Messintervall]
 Für Nodes mit Akku oder Solar empfiehlt es sich, das Sendeintervall großzügig zu wählen (z. B. alle 15–30 Minuten), um die Laufzeit zu verlängern.
 :::
 
@@ -54,7 +54,7 @@ INA219 oder INA260 liefern Strom und Spannung. Das Telemetry‑Modul überträgt
 
 Ein BME280 genügt für Temperatur, Luftfeuchtigkeit, Druck und Höhenschätzung. Bei tragbaren Geräten sind die Temperaturwerte eingeschränkt aussagekräftig, da Körperwärme oder direkte Sonneneinstrahlung die Messung beeinflussen.
 
-:::note Hinweis für mobile Geräte
+:::note[Hinweis für mobile Geräte]
 Sensorwerte können durch **Körperwärme, direkte Sonneneinstrahlung oder Berührung** verfälscht werden.
 :::
 
@@ -62,7 +62,7 @@ Sensorwerte können durch **Körperwärme, direkte Sonneneinstrahlung oder Berü
 
 Temperatur‑ und Feuchtesensoren gehören in ein belüftetes Gehäuse (Stevenson‑Screen), UV‑Sensoren brauchen freie Sicht nach oben, Regenmesser müssen waagerecht stehen.
 
-:::note Kondenswasser
+:::note[Kondenswasser]
 Feuchtigkeit im Gehäuse kann die Sensoren beeinflussen. Gleichzeitig kann der Messwert helfen, Feuchtigkeit im Gehäuse zu identifizieren.
 :::
 

--- a/docs/notfunk/naechste-uebung.md
+++ b/docs/notfunk/naechste-uebung.md
@@ -23,6 +23,6 @@ Weitere Informationen werden hier veröffentlicht, sobald sie vorliegen.
 
 ---
 
-:::info Auf dem Laufenden bleiben
+:::info[Auf dem Laufenden bleiben]
 Ankündigungen erscheinen auch in den WhatsApp-Communities von [Meshtastic](https://chat.whatsapp.com/CRYnRrAzhYeDlQEJQZQpKi) und [MeshCore](https://chat.whatsapp.com/JyNcTcgwlJf6Mhhf7vgYWD).
 :::


### PR DESCRIPTION
## Problem

Nach dem Update auf Docusaurus 3.10 wurden alle Admonitions mit Titeln als Literal-Text gerendert (z.B. `:::warning Titel` war sichtbar statt als Warnbox dargestellt).

## Ursache

Docusaurus 3.10 mit `future: { v4: true }` setzt `mdx1CompatDisabledByDefault: true`, was `mdx1Compat.admonitions: false` aktiviert. Dadurch wurde die automatische Konvertierung von `:::warning Titel` → `:::warning[Titel]` deaktiviert – alle Admonitions mit unformattierten Titeln wurden nicht mehr als Direktiven erkannt.

## Fix

55 Admonitions in 21 Dateien auf die neue Bracket-Syntax migriert:

```
:::warning Titel     →   :::warning[Titel]
:::note Hinweis      →   :::note[Hinweis]
:::tip Tipp          →   :::tip[Tipp]
```

Das ist die korrekte MDX-v2-Syntax, die ohne den Compat-Layer funktioniert.